### PR TITLE
update applications list to autogen

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Nerves.Firmware.HTTP.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :nerves_firmware, :cowboy, :exjsx],
+    [extra_applications: [:logger],
      mod: {Nerves.Firmware.HTTP, []}]
   end
 


### PR DESCRIPTION
This is going to require a bump release. Seems that it fails to build firmware properly when the applications list is looking for exjsx. Updated this to use the new structure so it autogenerates the list for you.