### PR TITLE
Add application supervisor

### DIFF
--- a/lib/firmware_http.ex
+++ b/lib/firmware_http.ex
@@ -1,5 +1,4 @@
 defmodule Nerves.Firmware.HTTP do
-
   @moduledoc """
   HTTP/JSON microservice to query and update firmware on a Nerves device.
 
@@ -31,13 +30,5 @@ defmodule Nerves.Firmware.HTTP do
                                       json_opts: [space: 1, indent: 2],
                                       timeout: 240_000
   """
-  @doc "Application start callback"
-  @spec start(atom, term) :: {:ok, pid} | {:error, String.t}
-  def start(_type, _args) do
-    port = Application.get_env(:nerves_firmware_http, :port, 8988)
-    path = Application.get_env(:nerves_firmware_http, :path, "/firmware")
-    timeout = Application.get_env(:nerves_firmware_http, :timeout, 120_000)
-    dispatch = :cowboy_router.compile [{:_,[{path, Nerves.Firmware.HTTP.Transport, []}]}]
-    :cowboy.start_http(__MODULE__, 10, [port: port], [env: [dispatch: dispatch], timeout: timeout])
-  end
+
 end

--- a/lib/firmware_http/application.ex
+++ b/lib/firmware_http/application.ex
@@ -1,0 +1,29 @@
+defmodule Nerves.Firmware.HTTP.Application do
+  use Application
+
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    # Define workers and child supervisors to be supervised
+    children = [
+      # worker(Nerves.Firmware.HTTP.Worker, [arg1, arg2, arg3])
+      worker(Task, [fn -> init() end], restart: :transient)
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Nerves.Firmware.HTTP.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def init do
+    port = Application.get_env(:nerves_firmware_http, :port, 8988)
+    path = Application.get_env(:nerves_firmware_http, :path, "/firmware")
+    timeout = Application.get_env(:nerves_firmware_http, :timeout, 120_000)
+    dispatch = :cowboy_router.compile [{:_,[{path, Nerves.Firmware.HTTP.Transport, []}]}]
+    :cowboy.start_http(__MODULE__, 10, [port: port], [env: [dispatch: dispatch], timeout: timeout])
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Nerves.Firmware.HTTP.Mixfile do
 
   def application do
     [extra_applications: [:logger],
-     mod: {Nerves.Firmware.HTTP, []}]
+     mod: {Nerves.Firmware.HTTP.Application, []}]
   end
 
   defp docs do


### PR DESCRIPTION
`nerves_firmware_http` is unable to stop when being asked to gracefully shutdown. Adding an application supervision tree allows the application to respect graceful shutdown when calls are made to `:init.stop`